### PR TITLE
Notify frontend

### DIFF
--- a/app/src/main/res/layout/fragment_battery.xml
+++ b/app/src/main/res/layout/fragment_battery.xml
@@ -40,7 +40,7 @@
                     android:layout_height="wrap_content"/>
         </LinearLayout>
         <Button
-
+                android:id="@+id/button_batteryLevelNotify"
                 android:textColor="@color/accent"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"

--- a/app/src/main/res/layout/fragment_battery.xml
+++ b/app/src/main/res/layout/fragment_battery.xml
@@ -39,5 +39,13 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"/>
         </LinearLayout>
+        <Button
+
+                android:textColor="@color/accent"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/notify"
+                android:layout_centerHorizontal="true"
+                android:layout_below="@id/batteryLevel"/>
     </RelativeLayout>
 </FrameLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,6 +2,7 @@
     <string name="app_name">BLE Test Peripheral</string>
     <string name="title_activity_peripherals">Peripherals</string>
     <string name="title_activity_peripheral">Peripheral</string>
+    <string name="notify">Notify</string>
 
     <!-- Bluetooth -->
     <string name="bluetoothNotSupported">BLE Test Peripheral closing: Bluetooth Not Supported</string>


### PR DESCRIPTION
Added a button to send a [notification](http://mbientlab.com/blog/bluetooth-low-energy-introduction/) to the Gatt Client. Please review @jyasskin @scheib 

![device-2015-03-18-170627](https://cloud.githubusercontent.com/assets/3117611/6722054/863e9560-cd91-11e4-90e3-523a928779d6.png)
