### PR TITLE
First iteration only including heart rate value and energy expended

### DIFF
--- a/app/src/main/res/layout/fragment_heart_rate.xml
+++ b/app/src/main/res/layout/fragment_heart_rate.xml
@@ -11,63 +11,67 @@
             android:gravity="center_vertical"
             android:layout_width="wrap_content"
             android:layout_height="48dp"/>
-    <TextView
-            android:id="@+id/label_bodySensorLocation"
-            android:text="@string/label_bodySensorLocation"
-            android:textAppearance="@style/label"
-            android:layout_width="wrap_content"
+    <GridLayout
+            android:id="@+id/gridLayout_characteristicsValues"
+            android:layout_width="fill_parent"
             android:layout_height="wrap_content"
-            android:layout_below="@id/textView_serviceName"/>
-    <Spinner
-            android:id="@+id/spinner_bodySensorLocation"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:entries="@array/location_values"
-            android:layout_alignTop="@+id/editText_heartRateMeasurementValue"
-            android:layout_alignBottom="@id/editText_heartRateMeasurementValue"/>
-    <TextView
-            android:id="@+id/label_heartRateMeasurementValue"
-            android:text="@string/label_heartRateMeasurementValue"
-            android:textAppearance="@style/label"
-            android:layout_marginStart="8dp"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_toEndOf="@id/spinner_bodySensorLocation"
-            android:layout_below="@id/textView_serviceName"/>
-    <EditText
-            android:id="@id/editText_heartRateMeasurementValue"
-            android:ems="3"
-            android:maxLength="3"
-            android:gravity="center"
-            android:inputType="number"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_alignStart="@id/label_heartRateMeasurementValue"
-            android:layout_below="@id/label_heartRateMeasurementValue"/>
-    <TextView
-            android:id="@+id/label_energyExpended"
-            android:text="@string/label_energyExpended"
-            android:textAppearance="@style/label"
-            android:layout_marginStart="8dp"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_toEndOf="@id/editText_heartRateMeasurementValue"
-            android:layout_below="@id/textView_serviceName"/>
-    <EditText
-            android:id="@+id/editText_energyExpended"
-            android:ems="4"
-            android:maxLength="5"
-            android:gravity="center"
-            android:inputType="number"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_alignStart="@id/label_energyExpended"
-            android:layout_below="@id/label_heartRateMeasurementValue"/>
+            android:rowCount="2"
+            android:columnCount="3"
+            android:layout_below="@id/textView_serviceName">
+        <TextView
+                android:id="@+id/label_bodySensorLocation"
+                android:text="@string/label_bodySensorLocation"
+                android:textAppearance="@style/label"
+                android:layout_gravity="fill"
+                android:layout_columnWeight="1"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"/>
+        <TextView
+                android:id="@+id/label_heartRateMeasurementValue"
+                android:text="@string/label_heartRateMeasurementValue"
+                android:textAppearance="@style/label"
+                android:layout_gravity="fill"
+                android:layout_columnWeight="1"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"/>
+        <TextView
+                android:id="@+id/label_energyExpended"
+                android:text="@string/label_energyExpended"
+                android:textAppearance="@style/label"
+                android:layout_gravity="fill"
+                android:layout_columnWeight="1"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"/>
+        <Spinner
+                android:id="@+id/spinner_bodySensorLocation"
+                android:layout_columnWeight="1"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:entries="@array/location_values"/>
+        <EditText
+                android:id="@+id/editText_heartRateMeasurementValue"
+                android:ems="3"
+                android:maxLength="3"
+                android:gravity="center"
+                android:inputType="number"
+                android:layout_columnWeight="1"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"/>
+        <EditText
+                android:id="@+id/editText_energyExpended"
+                android:ems="4"
+                android:maxLength="5"
+                android:gravity="center"
+                android:inputType="number"
+                android:layout_columnWeight="1"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"/>
+    </GridLayout>
     <Button
             android:id="@+id/button_heartRateMeasurementNotify"
             android:textColor="@color/accent"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/notify"
-            android:layout_below="@id/spinner_bodySensorLocation"/>
+            android:layout_below="@id/gridLayout_characteristicsValues"/>
 </RelativeLayout>

--- a/app/src/main/res/layout/fragment_heart_rate.xml
+++ b/app/src/main/res/layout/fragment_heart_rate.xml
@@ -15,7 +15,6 @@
             android:id="@+id/label_bodySensorLocation"
             android:text="@string/label_bodySensorLocation"
             android:textAppearance="@style/label"
-            android:layout_marginBottom="8dp"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_below="@id/textView_serviceName"/>
@@ -24,5 +23,51 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:entries="@array/location_values"
-            android:layout_below="@id/label_bodySensorLocation"/>
+            android:layout_alignTop="@+id/editText_heartRateMeasurementValue"
+            android:layout_alignBottom="@id/editText_heartRateMeasurementValue"/>
+    <TextView
+            android:id="@+id/label_heartRateMeasurementValue"
+            android:text="@string/label_heartRateMeasurementValue"
+            android:textAppearance="@style/label"
+            android:layout_marginStart="8dp"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_toEndOf="@id/spinner_bodySensorLocation"
+            android:layout_below="@id/textView_serviceName"/>
+    <EditText
+            android:id="@id/editText_heartRateMeasurementValue"
+            android:ems="3"
+            android:maxLength="3"
+            android:gravity="center"
+            android:inputType="number"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignStart="@id/label_heartRateMeasurementValue"
+            android:layout_below="@id/label_heartRateMeasurementValue"/>
+    <TextView
+            android:id="@+id/label_energyExpended"
+            android:text="@string/label_energyExpended"
+            android:textAppearance="@style/label"
+            android:layout_marginStart="8dp"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_toEndOf="@id/editText_heartRateMeasurementValue"
+            android:layout_below="@id/textView_serviceName"/>
+    <EditText
+            android:id="@+id/editText_energyExpended"
+            android:ems="4"
+            android:maxLength="5"
+            android:gravity="center"
+            android:inputType="number"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignStart="@id/label_energyExpended"
+            android:layout_below="@id/label_heartRateMeasurementValue"/>
+    <Button
+            android:id="@+id/button_heartRateMeasurementNotify"
+            android:textColor="@color/accent"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/notify"
+            android:layout_below="@id/spinner_bodySensorLocation"/>
 </RelativeLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -33,4 +33,6 @@
     <!-- Hear Rate Service -->
     <string name="label_bodySensorLocation">Body Sensor Location</string>
     <string name="heartRateServiceName">Heart Rate Service</string>
+    <string name="label_heartRateMeasurementValue">Heart Rate</string>
+    <string name="label_energyExpended">Energy Expended</string>
 </resources>


### PR DESCRIPTION
For the first iteration of the Heart Rate Measurement Characteristic I will only expose the [Heart Rate Measurement Value](https://developer.bluetooth.org/gatt/characteristics/Pages/CharacteristicViewer.aspx?u=org.bluetooth.characteristic.heart_rate_measurement.xml) and the [Energy Expended](https://developer.bluetooth.org/gatt/characteristics/Pages/CharacteristicViewer.aspx?u=org.bluetooth.characteristic.heart_rate_measurement.xml). These two values are sufficient to test `Notify` and `Write`. Please review @jyasskin @scheib 

![device-2015-03-20-163139](https://cloud.githubusercontent.com/assets/3117611/6762538/4be3cd7e-cf1f-11e4-9c74-fe2de760ccc1.png)
