### PR TITLE
Add support paired devices.

### DIFF
--- a/app/src/main/java/io/github/webbluetoothcg/bletestperipheral/Peripheral.java
+++ b/app/src/main/java/io/github/webbluetoothcg/bletestperipheral/Peripheral.java
@@ -38,7 +38,6 @@ import android.widget.Toast;
 
 import java.util.Arrays;
 import java.util.HashSet;
-import java.util.Set;
 
 import io.github.webbluetoothcg.bletestperipheral.ServiceFragment.ServiceFragmentDelegate;
 
@@ -217,10 +216,8 @@ public class Peripheral extends Activity implements ServiceFragmentDelegate {
         if (!mBluetoothAdapter.isMultipleAdvertisementSupported()) {
           Toast.makeText(this, R.string.bluetoothAdvertisingNotSupported, Toast.LENGTH_LONG).show();
           Log.e(TAG, "Advertising not supported");
-          finish();
-        } else {
-          onStart();
         }
+        onStart();
       } else {
         //TODO(g-ortuno): UX for asking the user to activate bt
         Toast.makeText(this, R.string.bluetoothNotEnabled, Toast.LENGTH_LONG).show();
@@ -242,14 +239,6 @@ public class Peripheral extends Activity implements ServiceFragmentDelegate {
       ensureBleFeaturesAvailable();
       return;
     }
-    Set<BluetoothDevice> devs = mBluetoothAdapter.getBondedDevices();
-    for (BluetoothDevice dev : devs) {
-      if (dev.getName() != null) {
-        Log.d(TAG, "YAYAY: " + dev.getName());
-      } else {
-        Log.d(TAG, "YAYAYY: " + dev.getAddress());
-      }
-    }
     // Add a service for a total of three services (Generic Attribute and Generic Access
     // are present by default).
     mGattServer.addService(mBluetoothGattService);
@@ -258,7 +247,7 @@ public class Peripheral extends Activity implements ServiceFragmentDelegate {
       mAdvertiser = mBluetoothAdapter.getBluetoothLeAdvertiser();
       mAdvertiser.startAdvertising(mAdvSettings, mAdvData, mAdvCallback);
     } else {
-      // TODO(g-ortuno): Add message to ask users to pair to be discoverable.
+      mAdvStatus.setText(R.string.status_noLeAdv);
     }
   }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -52,4 +52,7 @@
     <string name="label_energyExpended">Energy Expended</string>
     <string name="heartRateMeasurementValueInvalid">Please enter a number between 0 and 255</string>
     <string name="energyExpendedInvalid">Please enter a number between 0 and 65535</string>
+    <string name="status_noLeAdv">LE Advertising is not available. Please pair with a device to be
+        discoverable.
+    </string>
 </resources>


### PR DESCRIPTION
The app used to close if BLE Advertising was not available. Now the app doesn't. Now it is possible to discover the Services and Characteristics of the peripheral if the peripheral is paired with the central device.

![device-2015-04-15-161127](https://cloud.githubusercontent.com/assets/3117611/7209369/ffd041ee-e4fc-11e4-9525-773f6107ef19.png)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/webbluetoothcg/ble-test-peripheral-android/34)
<!-- Reviewable:end -->
