### PR TITLE
Peripherals now broadcast their service UUID.

### DIFF
--- a/app/src/main/java/io/github/webbluetoothcg/bletestperipheral/BatteryServiceFragment.java
+++ b/app/src/main/java/io/github/webbluetoothcg/bletestperipheral/BatteryServiceFragment.java
@@ -20,6 +20,7 @@ import android.app.Activity;
 import android.bluetooth.BluetoothGattCharacteristic;
 import android.bluetooth.BluetoothGattService;
 import android.os.Bundle;
+import android.os.ParcelUuid;
 import android.view.KeyEvent;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -153,6 +154,11 @@ public class BatteryServiceFragment extends ServiceFragment {
 
   public BluetoothGattService getBluetoothGattService() {
     return mBatteryService;
+  }
+
+  @Override
+  public ParcelUuid getServiceUUID() {
+    return new ParcelUuid(BATTERY_SERVICE_UUID);
   }
 
   private void setBatteryLevel(int newBatteryLevel, View source) {

--- a/app/src/main/java/io/github/webbluetoothcg/bletestperipheral/HeartRateServiceFragment.java
+++ b/app/src/main/java/io/github/webbluetoothcg/bletestperipheral/HeartRateServiceFragment.java
@@ -21,6 +21,7 @@ import android.bluetooth.BluetoothGatt;
 import android.bluetooth.BluetoothGattCharacteristic;
 import android.bluetooth.BluetoothGattService;
 import android.os.Bundle;
+import android.os.ParcelUuid;
 import android.util.Log;
 import android.view.KeyEvent;
 import android.view.LayoutInflater;
@@ -214,6 +215,11 @@ public class HeartRateServiceFragment extends ServiceFragment {
   @Override
   public BluetoothGattService getBluetoothGattService() {
     return mHeartRateService;
+  }
+
+  @Override
+  public ParcelUuid getServiceUUID() {
+    return new ParcelUuid(HEART_RATE_SERVICE_UUID);
   }
 
   private void setHeartRateMeasurementValue(int heartRateMeasurementValue, int expendedEnergy) {

--- a/app/src/main/java/io/github/webbluetoothcg/bletestperipheral/Peripheral.java
+++ b/app/src/main/java/io/github/webbluetoothcg/bletestperipheral/Peripheral.java
@@ -206,6 +206,7 @@ public class Peripheral extends Activity implements ServiceFragmentDelegate {
     mAdvData = new AdvertiseData.Builder()
         .setIncludeDeviceName(true)
         .setIncludeTxPowerLevel(true)
+        .addServiceUuid(mCurrentServiceFragment.getServiceUUID())
         .build();
   }
 

--- a/app/src/main/java/io/github/webbluetoothcg/bletestperipheral/ServiceFragment.java
+++ b/app/src/main/java/io/github/webbluetoothcg/bletestperipheral/ServiceFragment.java
@@ -19,9 +19,11 @@ package io.github.webbluetoothcg.bletestperipheral;
 import android.app.Fragment;
 import android.bluetooth.BluetoothGattCharacteristic;
 import android.bluetooth.BluetoothGattService;
+import android.os.ParcelUuid;
 
 public abstract class ServiceFragment extends Fragment{
   public abstract BluetoothGattService getBluetoothGattService();
+  public abstract ParcelUuid getServiceUUID();
 
   /**
    * Function to communicate to the ServiceFragment that a device wants to write to a


### PR DESCRIPTION
With this change the Peripheral App broadcasts the Service UUID of the Peripheral chosen.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/webbluetoothcg/ble-test-peripheral-android/36)
<!-- Reviewable:end -->
