### PR TITLE
Add descriptor to characteristics that support notifications

### DIFF
--- a/app/src/main/java/io/github/webbluetoothcg/bletestperipheral/BatteryServiceFragment.java
+++ b/app/src/main/java/io/github/webbluetoothcg/bletestperipheral/BatteryServiceFragment.java
@@ -49,9 +49,6 @@ public class BatteryServiceFragment extends ServiceFragment {
   private static final int INITIAL_BATTERY_LEVEL = 50;
   private static final int BATTERY_LEVEL_MAX = 100;
 
-  private static final UUID CLIENT_CHARACTERISTIC_CONFIGURATION_UUID = UUID
-      .fromString("00002902-0000-1000-8000-00805f9b34fb");
-
   private ServiceFragmentDelegate mDelegate;
   // UI
   private EditText mBatteryLevelEditText;
@@ -116,10 +113,8 @@ public class BatteryServiceFragment extends ServiceFragment {
             BluetoothGattCharacteristic.PROPERTY_READ | BluetoothGattCharacteristic.PROPERTY_NOTIFY,
             BluetoothGattCharacteristic.PERMISSION_READ);
 
-    BluetoothGattDescriptor clientCharacteristicConfigurationDescriptor =
-        new BluetoothGattDescriptor(CLIENT_CHARACTERISTIC_CONFIGURATION_UUID,
-            (BluetoothGattDescriptor.PERMISSION_READ | BluetoothGattDescriptor.PERMISSION_WRITE));
-    mBatteryLevelCharacteristic.addDescriptor(clientCharacteristicConfigurationDescriptor);
+    mBatteryLevelCharacteristic.addDescriptor(
+        Peripheral.getClientCharacteristicConfigurationDescriptor());
 
     mBatteryService = new BluetoothGattService(BATTERY_SERVICE_UUID,
         BluetoothGattService.SERVICE_TYPE_PRIMARY);

--- a/app/src/main/java/io/github/webbluetoothcg/bletestperipheral/BatteryServiceFragment.java
+++ b/app/src/main/java/io/github/webbluetoothcg/bletestperipheral/BatteryServiceFragment.java
@@ -18,6 +18,7 @@ package io.github.webbluetoothcg.bletestperipheral;
 
 import android.app.Activity;
 import android.bluetooth.BluetoothGattCharacteristic;
+import android.bluetooth.BluetoothGattDescriptor;
 import android.bluetooth.BluetoothGattService;
 import android.os.Bundle;
 import android.os.ParcelUuid;
@@ -47,6 +48,9 @@ public class BatteryServiceFragment extends ServiceFragment {
       .fromString("00002A19-0000-1000-8000-00805f9b34fb");
   private static final int INITIAL_BATTERY_LEVEL = 50;
   private static final int BATTERY_LEVEL_MAX = 100;
+
+  private static final UUID CLIENT_CHARACTERISTIC_CONFIGURATION_UUID = UUID
+      .fromString("00002902-0000-1000-8000-00805f9b34fb");
 
   private ServiceFragmentDelegate mDelegate;
   // UI
@@ -111,6 +115,11 @@ public class BatteryServiceFragment extends ServiceFragment {
         new BluetoothGattCharacteristic(BATTERY_LEVEL_UUID,
             BluetoothGattCharacteristic.PROPERTY_READ | BluetoothGattCharacteristic.PROPERTY_NOTIFY,
             BluetoothGattCharacteristic.PERMISSION_READ);
+
+    BluetoothGattDescriptor clientCharacteristicConfigurationDescriptor =
+        new BluetoothGattDescriptor(CLIENT_CHARACTERISTIC_CONFIGURATION_UUID,
+            (BluetoothGattDescriptor.PERMISSION_READ | BluetoothGattDescriptor.PERMISSION_WRITE));
+    mBatteryLevelCharacteristic.addDescriptor(clientCharacteristicConfigurationDescriptor);
 
     mBatteryService = new BluetoothGattService(BATTERY_SERVICE_UUID,
         BluetoothGattService.SERVICE_TYPE_PRIMARY);

--- a/app/src/main/java/io/github/webbluetoothcg/bletestperipheral/HeartRateServiceFragment.java
+++ b/app/src/main/java/io/github/webbluetoothcg/bletestperipheral/HeartRateServiceFragment.java
@@ -65,9 +65,6 @@ public class HeartRateServiceFragment extends ServiceFragment {
   private static final int EXPENDED_ENERGY_FORMAT = BluetoothGattCharacteristic.FORMAT_UINT16;
   private static final int INITIAL_EXPENDED_ENERGY = 0;
 
-  private static final UUID CLIENT_CHARACTERISTIC_CONFIGURATION_UUID = UUID
-      .fromString("00002902-0000-1000-8000-00805f9b34fb");
-
   /**
    * See <a href="https://developer.bluetooth.org/gatt/characteristics/Pages/CharacteristicViewer.aspx?u=org.bluetooth.characteristic.body_sensor_location.xml">
    * Body Sensor Location</a>
@@ -158,10 +155,8 @@ public class HeartRateServiceFragment extends ServiceFragment {
             BluetoothGattCharacteristic.PROPERTY_NOTIFY,
             /* No permissions */ 0);
 
-    BluetoothGattDescriptor clientCharacteristicConfigurationDescriptor =
-        new BluetoothGattDescriptor(CLIENT_CHARACTERISTIC_CONFIGURATION_UUID,
-            (BluetoothGattDescriptor.PERMISSION_READ | BluetoothGattDescriptor.PERMISSION_WRITE));
-    mHeartRateMeasurementCharacteristic.addDescriptor(clientCharacteristicConfigurationDescriptor);
+    mHeartRateMeasurementCharacteristic.addDescriptor(
+        Peripheral.getClientCharacteristicConfigurationDescriptor());
 
     mBodySensorLocationCharacteristic =
         new BluetoothGattCharacteristic(BODY_SENSOR_LOCATION_UUID,

--- a/app/src/main/java/io/github/webbluetoothcg/bletestperipheral/HeartRateServiceFragment.java
+++ b/app/src/main/java/io/github/webbluetoothcg/bletestperipheral/HeartRateServiceFragment.java
@@ -19,6 +19,7 @@ package io.github.webbluetoothcg.bletestperipheral;
 import android.app.Activity;
 import android.bluetooth.BluetoothGatt;
 import android.bluetooth.BluetoothGattCharacteristic;
+import android.bluetooth.BluetoothGattDescriptor;
 import android.bluetooth.BluetoothGattService;
 import android.os.Bundle;
 import android.os.ParcelUuid;
@@ -63,6 +64,10 @@ public class HeartRateServiceFragment extends ServiceFragment {
   private static final int INITIAL_HEART_RATE_MEASUREMENT_VALUE = 60;
   private static final int EXPENDED_ENERGY_FORMAT = BluetoothGattCharacteristic.FORMAT_UINT16;
   private static final int INITIAL_EXPENDED_ENERGY = 0;
+
+  private static final UUID CLIENT_CHARACTERISTIC_CONFIGURATION_UUID = UUID
+      .fromString("00002902-0000-1000-8000-00805f9b34fb");
+
   /**
    * See <a href="https://developer.bluetooth.org/gatt/characteristics/Pages/CharacteristicViewer.aspx?u=org.bluetooth.characteristic.body_sensor_location.xml">
    * Body Sensor Location</a>
@@ -152,6 +157,11 @@ public class HeartRateServiceFragment extends ServiceFragment {
         new BluetoothGattCharacteristic(HEART_RATE_MEASUREMENT_UUID,
             BluetoothGattCharacteristic.PROPERTY_NOTIFY,
             /* No permissions */ 0);
+
+    BluetoothGattDescriptor clientCharacteristicConfigurationDescriptor =
+        new BluetoothGattDescriptor(CLIENT_CHARACTERISTIC_CONFIGURATION_UUID,
+            (BluetoothGattDescriptor.PERMISSION_READ | BluetoothGattDescriptor.PERMISSION_WRITE));
+    mHeartRateMeasurementCharacteristic.addDescriptor(clientCharacteristicConfigurationDescriptor);
 
     mBodySensorLocationCharacteristic =
         new BluetoothGattCharacteristic(BODY_SENSOR_LOCATION_UUID,

--- a/app/src/main/java/io/github/webbluetoothcg/bletestperipheral/Peripheral.java
+++ b/app/src/main/java/io/github/webbluetoothcg/bletestperipheral/Peripheral.java
@@ -21,6 +21,7 @@ import android.bluetooth.BluetoothAdapter;
 import android.bluetooth.BluetoothDevice;
 import android.bluetooth.BluetoothGatt;
 import android.bluetooth.BluetoothGattCharacteristic;
+import android.bluetooth.BluetoothGattDescriptor;
 import android.bluetooth.BluetoothGattServer;
 import android.bluetooth.BluetoothGattServerCallback;
 import android.bluetooth.BluetoothGattService;
@@ -162,6 +163,28 @@ public class Peripheral extends Activity implements ServiceFragmentDelegate {
       if (responseNeeded) {
         mGattServer.sendResponse(device, requestId, status,
             /* No need to respond with an offset */ 0,
+            /* No need to respond with a value */ null);
+      }
+    }
+
+    @Override
+    public void onDescriptorReadRequest(BluetoothDevice device, int requestId, int offset,
+        BluetoothGattDescriptor descriptor) {
+      Log.v(TAG, "Descriptor Read Request: " + descriptor.getUuid());
+      super.onDescriptorReadRequest(device, requestId, offset, descriptor);
+    }
+
+    @Override
+    public void onDescriptorWriteRequest(BluetoothDevice device, int requestId,
+        BluetoothGattDescriptor descriptor, boolean preparedWrite, boolean responseNeeded,
+        int offset,
+        byte[] value) {
+      Log.v(TAG, "Descriptor Write Request " + descriptor.getUuid() + " " + Arrays.toString(value));
+      super.onDescriptorWriteRequest(device, requestId, descriptor, preparedWrite, responseNeeded,
+          offset, value);
+      if(responseNeeded) {
+        mGattServer.sendResponse(device, requestId, BluetoothGatt.GATT_SUCCESS,
+            /* No need to respond with offset */ 0,
             /* No need to respond with a value */ null);
       }
     }

--- a/app/src/main/java/io/github/webbluetoothcg/bletestperipheral/Peripheral.java
+++ b/app/src/main/java/io/github/webbluetoothcg/bletestperipheral/Peripheral.java
@@ -43,6 +43,7 @@ import android.widget.Toast;
 
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.UUID;
 
 import io.github.webbluetoothcg.bletestperipheral.ServiceFragment.ServiceFragmentDelegate;
 
@@ -51,6 +52,9 @@ public class Peripheral extends Activity implements ServiceFragmentDelegate {
   private static final int REQUEST_ENABLE_BT = 1;
   private static final String TAG = Peripheral.class.getCanonicalName();
   private static final String CURRENT_FRAGMENT_TAG = "CURRENT_FRAGMENT";
+
+  private static final UUID CLIENT_CHARACTERISTIC_CONFIGURATION_UUID = UUID
+      .fromString("00002902-0000-1000-8000-00805f9b34fb");
 
   private TextView mAdvStatus;
   private TextView mConnectionStatus;
@@ -165,13 +169,6 @@ public class Peripheral extends Activity implements ServiceFragmentDelegate {
             /* No need to respond with an offset */ 0,
             /* No need to respond with a value */ null);
       }
-    }
-
-    @Override
-    public void onDescriptorReadRequest(BluetoothDevice device, int requestId, int offset,
-        BluetoothGattDescriptor descriptor) {
-      Log.v(TAG, "Descriptor Read Request: " + descriptor.getUuid());
-      super.onDescriptorReadRequest(device, requestId, offset, descriptor);
     }
 
     @Override
@@ -345,6 +342,11 @@ public class Peripheral extends Activity implements ServiceFragmentDelegate {
   ///////////////////////
   ////// Bluetooth //////
   ///////////////////////
+  public static BluetoothGattDescriptor getClientCharacteristicConfigurationDescriptor() {
+    return new BluetoothGattDescriptor(CLIENT_CHARACTERISTIC_CONFIGURATION_UUID,
+            (BluetoothGattDescriptor.PERMISSION_READ | BluetoothGattDescriptor.PERMISSION_WRITE));
+  }
+
   private void ensureBleFeaturesAvailable() {
     if (mBluetoothAdapter == null) {
       Toast.makeText(this, R.string.bluetoothNotSupported, Toast.LENGTH_LONG).show();

--- a/app/src/main/java/io/github/webbluetoothcg/bletestperipheral/ServiceFragment.java
+++ b/app/src/main/java/io/github/webbluetoothcg/bletestperipheral/ServiceFragment.java
@@ -18,6 +18,7 @@ package io.github.webbluetoothcg.bletestperipheral;
 
 import android.app.Fragment;
 import android.bluetooth.BluetoothGattCharacteristic;
+import android.bluetooth.BluetoothGattDescriptor;
 import android.bluetooth.BluetoothGattService;
 import android.os.ParcelUuid;
 


### PR DESCRIPTION
To fully support notifications each Bluetooth Characteristic that wants to send notifications should have a Client Characteristic Configuration Descriptor.

@scheib: PTAL