### PR TITLE
Add scan response

### DIFF
--- a/app/src/main/java/io/github/webbluetoothcg/bletestperipheral/Peripheral.java
+++ b/app/src/main/java/io/github/webbluetoothcg/bletestperipheral/Peripheral.java
@@ -64,6 +64,7 @@ public class Peripheral extends Activity implements ServiceFragmentDelegate {
   private BluetoothManager mBluetoothManager;
   private BluetoothAdapter mBluetoothAdapter;
   private AdvertiseData mAdvData;
+  private AdvertiseData mAdvScanResponse;
   private AdvertiseSettings mAdvSettings;
   private BluetoothLeAdvertiser mAdvertiser;
   private final AdvertiseCallback mAdvCallback = new AdvertiseCallback() {
@@ -229,9 +230,11 @@ public class Peripheral extends Activity implements ServiceFragmentDelegate {
         .setConnectable(true)
         .build();
     mAdvData = new AdvertiseData.Builder()
-        .setIncludeDeviceName(true)
         .setIncludeTxPowerLevel(true)
         .addServiceUuid(mCurrentServiceFragment.getServiceUUID())
+        .build();
+    mAdvScanResponse = new AdvertiseData.Builder()
+        .setIncludeDeviceName(true)
         .build();
   }
 
@@ -279,7 +282,7 @@ public class Peripheral extends Activity implements ServiceFragmentDelegate {
 
     if (mBluetoothAdapter.isMultipleAdvertisementSupported()) {
       mAdvertiser = mBluetoothAdapter.getBluetoothLeAdvertiser();
-      mAdvertiser.startAdvertising(mAdvSettings, mAdvData, mAdvCallback);
+      mAdvertiser.startAdvertising(mAdvSettings, mAdvData, mAdvScanResponse, mAdvCallback);
     } else {
       mAdvStatus.setText(R.string.status_noLeAdv);
     }

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.3.0'
+        classpath 'com.android.tools.build:gradle:2.1.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Apr 10 15:27:10 PDT 2013
+#Wed Aug 24 14:14:02 CEST 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip


### PR DESCRIPTION
I believe this should help with https://github.com/WebBluetoothCG/ble-test-peripheral-android/issues/68 as Device Name will only be advertised in advertising scan response.

R: @g-ortuno
FIX: #68 