### PR TITLE
Update version for new release

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,8 +8,8 @@ android {
         applicationId "io.github.webbluetoothcg.bletestperipheral"
         minSdkVersion 21
         targetSdkVersion 22
-        versionCode 7
-        versionName "7.0"
+        versionCode 8
+        versionName "8.0"
     }
     buildTypes {
         release {


### PR DESCRIPTION
Following https://github.com/WebBluetoothCG/ble-test-peripheral-android/pull/70, here's the patch that needs to be applied to update the app to the Play Store.

R:@g-ortuno